### PR TITLE
Added set nolist to syntax files.

### DIFF
--- a/syntax/vimptvpa.vim
+++ b/syntax/vimptvpa.vim
@@ -15,6 +15,7 @@ syntax case ignore
 syntax sync fromstart
 set nowrap
 
+set nolist
 
 highlight   VPAInverse       ctermfg=white      ctermbg=black
 highlight   VPABackground    ctermfg=white      ctermbg=white

--- a/syntax/vimptvpe.vim
+++ b/syntax/vimptvpe.vim
@@ -13,6 +13,8 @@ endif
 
 syntax case ignore
 
+set nolist
+
 highlight   VPEText     ctermfg=white      ctermbg=black 
 
 syn match  VPEText  /./

--- a/syntax/vimptvpf.vim
+++ b/syntax/vimptvpf.vim
@@ -15,7 +15,7 @@ endif
 syntax case ignore
 syntax sync fromstart
 set nowrap
-
+set nolist
 
 highlight   VPFBackground     ctermfg=white      ctermbg=white 
 

--- a/syntax/vimptvpi.vim
+++ b/syntax/vimptvpi.vim
@@ -15,6 +15,7 @@ endif
 syntax case ignore
 syntax sync fromstart
 set nowrap
+set nolist
 
 
 highlight   VPIBackground     ctermfg=white      ctermbg=white 

--- a/syntax/vimptvps.vim
+++ b/syntax/vimptvps.vim
@@ -14,6 +14,7 @@ endif
 syntax case ignore
 syntax sync fromstart
 set nowrap
+set nolist
 
 
 highlight   VPSBackground    ctermfg=white      ctermbg=white

--- a/syntax/vimptvpt.vim
+++ b/syntax/vimptvpt.vim
@@ -15,6 +15,7 @@ endif
 syntax case ignore
 syntax sync fromstart
 set nowrap
+set nolist
 
 
 highlight   VPTBulletPoint       ctermfg=yellow   cterm=bold


### PR DESCRIPTION
When using set list to show whitespace characters the slide backgrounds are replaced with the special characters instead of the actual background.

Before: 
![screen shot 2013-11-15 at 11 20 05 am](https://f.cloud.github.com/assets/1445303/1551824/4cac82e6-4e1a-11e3-9d0d-007fd9ace4ea.png)

After:
![screen shot 2013-11-15 at 11 21 27 am](https://f.cloud.github.com/assets/1445303/1551828/6498d198-4e1a-11e3-8cd0-6f6856b79f83.png)
